### PR TITLE
Add Grantmakers.io

### DIFF
--- a/datasets/irs990.yaml
+++ b/datasets/irs990.yaml
@@ -41,3 +41,7 @@ DataAtWork:
     URL: https://medium.com/@open990/the-irs-990-e-file-dataset-getting-to-the-chocolatey-center-of-data-deliciousness-90f66097a600
     AuthorName: 990 Consulting, LLC
     AuthorURL: https://www.990consulting.com/
+  - Title: Grantmakers.io
+    URL: https://www.grantmakers.io
+    AuthorName: Chad Kruse
+    AuthorURL: https://www.chadkruse.com/


### PR DESCRIPTION
Grantmakers.io leverages the public IRS 990 dataset hosted by AWS, focusing exclusively on Form 990-PF (the form filed by grantmaking institutions). Fully open source and forever free.